### PR TITLE
인증/랭킹/출석 안정화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,6 @@ logs/
 *.log
 # Environment variables
 backend/.env
+
+# Local contributor guide (do not track)
+AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,3 @@ logs/
 *.log
 # Environment variables
 backend/.env
-
-# Local contributor guide (do not track)
-AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `backend/solsol/`: Spring Boot (Gradle). Source in `src/main/java`, tests in `src/test/java`, config in `src/main/resources`. Build files: `build.gradle`, `gradlew`.
+- `backend/.env`: Active backend environment (hidden). Template: `backend/solsol/env.example` (see also `README-ENV.md`).
+- `frontend/`: Vite + Vue 3 + TypeScript. App lives in `frontend/solsol/` (`index.html`, `src/`); static assets in `frontend/public/`.
+- `documents/`, `logs/`: Reference and runtime artifacts. Do not commit secrets.
+
+## Build, Test, and Development Commands
+- Backend run: `cd backend/solsol && ./gradlew bootRun` — starts API on `http://localhost:8080` with `local` profile.
+- Backend test: `./gradlew test` — runs JUnit 5 tests.
+- Backend build: `./gradlew build` — creates JAR in `build/libs/`.
+- Rate limit check: `cd backend/solsol && ./test-rate-limit.sh` — smoke-test rate limiting.
+- Frontend dev: `cd frontend && npm ci && npm run dev` — Vite dev server on `http://localhost:5173`.
+- Frontend build: `npm run build` — outputs to `frontend/dist/`.
+
+## Coding Style & Naming Conventions
+- Java 17, Spring conventions, package-by-feature (e.g., `auth/`, `mascot/`, `finance/`). Classes `PascalCase`; methods/fields `camelCase`; DTOs end with `Request`/`Response`; controllers end with `Controller`.
+- Vue/TS: components `PascalCase.vue` in `components/` or feature folders; pages in `views/`. Shared types in `src/types/`. Keep API clients under `src/api/`.
+- Indentation: 4 spaces (Java), 2 spaces (FE). Keep imports organized; no enforced linter—follow existing patterns.
+
+## Testing Guidelines
+- Backend: Place tests under `backend/solsol/src/test/java/...` mirroring package paths. File names: `*Tests.java` or `*Test.java`. Run with `./gradlew test`.
+- Target: service/business logic and controller behavior; prefer mocking external integrations.
+- Frontend: No test runner configured—propose and align before adding tests.
+
+## Commit & Pull Request Guidelines
+- Branches: `main` (release), `develop` (integration), `feature/<scope>`.
+- Commits (conventional): `feat: add mascot equip API`, `fix: handle JWT expiration`, `docs: update README`.
+- PRs: include purpose, linked issues, steps to verify (commands/URLs), and screenshots for UI changes. Keep scope focused; update `env.example`/docs when config changes.
+
+## Security & Configuration Tips
+- Copy `backend/solsol/env.example` to `backend/.env` and set: `JWT_SECRET_KEY`, `DB_*`, `CORS_ALLOWED_ORIGINS`, `FINANCE_API_KEY`.
+- Profiles: `SPRING_PROFILES_ACTIVE=local|dev|prod`. In prod, disable dev-only surfaces (H2, Swagger) and restrict CORS. Never commit `.env`.
+

--- a/backend/solsol/src/main/java/com/solsolhey/auth/controller/AuthController.java
+++ b/backend/solsol/src/main/java/com/solsolhey/auth/controller/AuthController.java
@@ -176,15 +176,25 @@ public class AuthController {
      */
     @GetMapping("/me")
     @Operation(summary = "세션 확인", description = "현재 로그인한 사용자 정보를 반환합니다(인증 필요).")
-    public ResponseEntity<ApiResponse<Map<String,Object>>> me(Authentication authentication) {
-        if (authentication == null || !authentication.isAuthenticated()) {
+    public ResponseEntity<ApiResponse<com.solsolhey.user.dto.response.UserResponse>> me(
+            @org.springframework.security.core.annotation.AuthenticationPrincipal com.solsolhey.auth.dto.response.CustomUserDetails userDetails) {
+        if (userDetails == null || !userDetails.isEnabled()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ApiResponse.error(HttpStatus.UNAUTHORIZED, "인증되지 않았습니다."));
         }
-        String principal = String.valueOf(authentication.getName());
-        return ResponseEntity.ok(ApiResponse.success("OK", Map.of(
-            "username", principal
-            // 필요 시 userId/nickname은 실제 값으로 채우거나 생략
-        )));
+
+        var u = userDetails.getUser();
+        var dto = new com.solsolhey.user.dto.response.UserResponse(
+                u.getUserId(),
+                u.getUsername(),
+                u.getEmail(),
+                u.getNickname(),
+                u.getCampus(),
+                u.getTotalPoints(),
+                u.getIsActive(),
+                u.getCreatedAt(),
+                u.getUpdatedAt()
+        );
+        return ResponseEntity.ok(ApiResponse.success("OK", dto));
     }
 }

--- a/backend/solsol/src/main/java/com/solsolhey/common/config/SecurityConfig.java
+++ b/backend/solsol/src/main/java/com/solsolhey/common/config/SecurityConfig.java
@@ -76,6 +76,8 @@ public class SecurityConfig {
                 .requestMatchers("/health", "/actuator/**", "/api/v1/auth/**").permitAll()
                 .requestMatchers(HttpMethod.POST, "/api/v1/mascot").authenticated()
                 .requestMatchers(HttpMethod.POST, "/api/v1/friends/requests").authenticated()
+                .requestMatchers(HttpMethod.POST, "/api/v1/attendance").authenticated()
+                .requestMatchers(HttpMethod.GET, "/api/v1/attendance/**").authenticated()
                 .anyRequest().permitAll()
             )
             // Run your custom rate limit filter early (kept as before)
@@ -96,13 +98,18 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        
-        // SPA용 CORS 설정
-        configuration.setAllowedOriginPatterns(List.of("http://localhost:5173"));
-        configuration.setAllowCredentials(true);
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(List.of("Content-Type", "X-XSRF-TOKEN", "Authorization", "Accept"));
-        configuration.setMaxAge(3600L);
+
+        String origins = environment.getProperty("cors.allowed-origins", "http://localhost:5173");
+        String methods = environment.getProperty("cors.allowed-methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS");
+        String headers = environment.getProperty("cors.allowed-headers", "*");
+        boolean allowCreds = Boolean.parseBoolean(environment.getProperty("cors.allow-credentials", "true"));
+        long maxAge = Long.parseLong(environment.getProperty("cors.max-age", "3600"));
+
+        configuration.setAllowedOriginPatterns(Arrays.stream(origins.split(",")).map(String::trim).toList());
+        configuration.setAllowedMethods(Arrays.stream(methods.split(",")).map(String::trim).toList());
+        configuration.setAllowedHeaders(Arrays.stream(headers.split(",")).map(String::trim).toList());
+        configuration.setAllowCredentials(allowCreds);
+        configuration.setMaxAge(maxAge);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/backend/solsol/src/main/java/com/solsolhey/ranking/controller/RankingController.java
+++ b/backend/solsol/src/main/java/com/solsolhey/ranking/controller/RankingController.java
@@ -37,7 +37,7 @@ public class RankingController {
      * 교내 랭킹 조회
      */
     @GetMapping("/campus")
-    @PreAuthorize("hasRole('MASTER')")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "교내 랭킹 조회", description = "캠퍼스별 마스코트 콘테스트 랭킹을 조회합니다")
     public ResponseEntity<ApiResponse<RankingResponse>> getCampusRankings(
             @Parameter(description = "캠퍼스 ID") @RequestParam(required = false) Long campusId,
@@ -74,7 +74,7 @@ public class RankingController {
      * 전국 랭킹 조회
      */
     @GetMapping("/national")
-    @PreAuthorize("hasRole('MASTER')")
+    @PreAuthorize("isAuthenticated()")
     @Operation(summary = "전국 랭킹 조회", description = "전국 마스코트 콘테스트 랭킹을 조회합니다")
     public ResponseEntity<ApiResponse<RankingResponse>> getNationalRankings(
             @Parameter(description = "정렬 기준 (votes_desc, trending, newest)") @RequestParam(defaultValue = "votes_desc") String sort,

--- a/backend/solsol/src/main/java/com/solsolhey/user/controller/AttendanceController.java
+++ b/backend/solsol/src/main/java/com/solsolhey/user/controller/AttendanceController.java
@@ -1,0 +1,60 @@
+package com.solsolhey.user.controller;
+
+import com.solsolhey.auth.dto.response.CustomUserDetails;
+import com.solsolhey.common.response.ApiResponse;
+import com.solsolhey.user.service.AttendanceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/attendance")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Attendance API", description = "출석 체크 API")
+public class AttendanceController {
+
+    private final AttendanceService attendanceService;
+
+    @GetMapping("/today")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "오늘 출석 여부", description = "오늘 출석했는지 여부를 반환합니다")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> hasToday(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        boolean attended = attendanceService.hasAttendedToday(userDetails.getUser());
+        return ResponseEntity.ok(ApiResponse.success("OK", Map.of("attended", attended)));
+    }
+
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "출석 체크", description = "오늘 출석을 기록하고 보상을 지급합니다")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> checkIn(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        try {
+            var result = attendanceService.checkInToday(userDetails.getUser());
+            return ResponseEntity.status(HttpStatus.CREATED).body(
+                    ApiResponse.success("출석 완료", Map.of(
+                            "attended", result.attended(),
+                            "consecutiveDays", result.consecutiveDays(),
+                            "expReward", result.expReward(),
+                            "pointReward", result.pointReward()
+                    )));
+        } catch (Exception e) {
+            log.error("출석 처리 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.internalServerError("출석 처리 중 오류가 발생했습니다."));
+        }
+    }
+}
+

--- a/backend/solsol/src/main/java/com/solsolhey/user/repository/AttendanceRepository.java
+++ b/backend/solsol/src/main/java/com/solsolhey/user/repository/AttendanceRepository.java
@@ -1,0 +1,18 @@
+package com.solsolhey.user.repository;
+
+import com.solsolhey.user.entity.Attendance;
+import com.solsolhey.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+
+    boolean existsByUserAndAttendanceDate(User user, LocalDate attendanceDate);
+
+    Optional<Attendance> findTopByUserOrderByAttendanceDateDesc(User user);
+}
+

--- a/backend/solsol/src/main/java/com/solsolhey/user/service/AttendanceService.java
+++ b/backend/solsol/src/main/java/com/solsolhey/user/service/AttendanceService.java
@@ -1,0 +1,19 @@
+package com.solsolhey.user.service;
+
+import com.solsolhey.user.entity.User;
+
+public interface AttendanceService {
+
+    /**
+     * 오늘 출석 여부 확인
+     */
+    boolean hasAttendedToday(User user);
+
+    /**
+     * 오늘 출석 처리 및 보상 지급
+     */
+    AttendanceResult checkInToday(User user);
+
+    record AttendanceResult(boolean attended, int consecutiveDays, int expReward, int pointReward) {}
+}
+

--- a/backend/solsol/src/main/java/com/solsolhey/user/service/AttendanceServiceImpl.java
+++ b/backend/solsol/src/main/java/com/solsolhey/user/service/AttendanceServiceImpl.java
@@ -1,0 +1,74 @@
+package com.solsolhey.user.service;
+
+import com.solsolhey.point.service.PointService;
+import com.solsolhey.point.dto.response.PointTransactionResponse;
+import com.solsolhey.point.entity.PointTransaction.ReferenceType;
+import com.solsolhey.user.entity.Attendance;
+import com.solsolhey.user.entity.User;
+import com.solsolhey.user.repository.AttendanceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class AttendanceServiceImpl implements AttendanceService {
+
+    private final AttendanceRepository attendanceRepository;
+    private final PointService pointService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasAttendedToday(User user) {
+        return attendanceRepository.existsByUserAndAttendanceDate(user, LocalDate.now());
+    }
+
+    @Override
+    public AttendanceResult checkInToday(User user) {
+        LocalDate today = LocalDate.now();
+
+        if (attendanceRepository.existsByUserAndAttendanceDate(user, today)) {
+            log.info("이미 오늘 출석함: userId={}", user.getUserId());
+            Attendance latest = attendanceRepository.findTopByUserOrderByAttendanceDateDesc(user).orElse(null);
+            int consecutive = latest != null ? latest.getConsecutiveDays() : 1;
+            return new AttendanceResult(true, consecutive, latest != null ? latest.getExpReward() : 0, latest != null ? latest.getPointReward() : 0);
+        }
+
+        int consecutiveDays = 1;
+        var latestOpt = attendanceRepository.findTopByUserOrderByAttendanceDateDesc(user);
+        if (latestOpt.isPresent()) {
+            LocalDate lastDate = latestOpt.get().getAttendanceDate();
+            if (ChronoUnit.DAYS.between(lastDate, today) == 1) {
+                consecutiveDays = latestOpt.get().getConsecutiveDays() + 1;
+            } else {
+                consecutiveDays = 1;
+            }
+        }
+
+        Attendance attendance = Attendance.builder()
+                .user(user)
+                .attendanceDate(today)
+                .consecutiveDays(consecutiveDays)
+                .build();
+
+        try {
+            attendanceRepository.save(attendance);
+        } catch (DataIntegrityViolationException e) {
+            // 유니크 제약(사용자+날짜) 충돌 시 이미 출석 처리된 것으로 간주
+            log.warn("동시성으로 인한 출석 중복 저장: userId={}", user.getUserId());
+        }
+
+        // 포인트 지급 (일일 보너스)
+        PointTransactionResponse tx = pointService.giveDailyBonus(user);
+
+        return new AttendanceResult(true, attendance.getConsecutiveDays(), attendance.getExpReward(), tx.pointAmount());
+    }
+}
+

--- a/backend/solsol/src/main/resources/db/migration/V1_1__add_unique_indexes_mascots_votes.sql
+++ b/backend/solsol/src/main/resources/db/migration/V1_1__add_unique_indexes_mascots_votes.sql
@@ -1,0 +1,6 @@
+-- Add unique index to ensure one mascot per user
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mascots_user_id ON mascots(user_id);
+
+-- Enforce idempotency on votes by unique idempotency_key when provided
+CREATE UNIQUE INDEX IF NOT EXISTS ux_votes_idempotency_key ON votes(idempotency_key);
+

--- a/frontend/solsol/src/views/Attendance.vue
+++ b/frontend/solsol/src/views/Attendance.vue
@@ -141,6 +141,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
+import { apiRequest } from '../api/index';
 import { auth } from '../api/index';
 
 const router = useRouter();
@@ -273,23 +274,8 @@ function nextMonth() {
 // 출석체크
 async function checkAttendance() {
   try {
-    // 실제 API 호출
-    const response = await fetch('http://localhost:8080/api/attendance', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${localStorage.getItem('token')}`
-      },
-      body: JSON.stringify({
-        attendanceDate: new Date().toISOString().split('T')[0]
-      })
-    });
-
-    if (!response.ok) {
-      throw new Error('출석체크 API 호출 실패');
-    }
-
-    const result = await response.json();
+    // 실제 API 호출 (쿠키+CSRF는 apiRequest가 처리)
+    const result = await apiRequest<any>('/attendance', { method: 'POST' });
     
     // API 호출 성공 시에만 상태 변경
     todayAttended.value = true;
@@ -309,19 +295,8 @@ async function checkAttendance() {
 onMounted(async () => {
   try {
     // 오늘 출석 상태 확인 API 호출
-    const response = await fetch('http://localhost:8080/api/attendance/today', {
-      method: 'GET',
-      headers: {
-        'Authorization': `Bearer ${localStorage.getItem('token')}`
-      }
-    });
-
-    if (response.ok) {
-      const result = await response.json();
-      todayAttended.value = result.attended || false;
-    } else {
-      todayAttended.value = false;
-    }
+    const res = await apiRequest<any>('/attendance/today');
+    todayAttended.value = !!res?.data?.attended;
   } catch (error) {
     console.error('오늘 출석 상태 확인 오류:', error);
     todayAttended.value = false;

--- a/frontend/solsol/src/views/Mascot.vue
+++ b/frontend/solsol/src/views/Mascot.vue
@@ -289,7 +289,7 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { mascotTypes, levelExperience, realItems } from '../data/mockData';
-import { getMascot, handleApiError, auth, createShareLink, createShareImage, ShareType, ImageType, type ShareLinkCreateRequest, type ShareImageCreateRequest } from '../api/index';
+import { getMascot, handleApiError, auth, createShareLink, createShareImage, getAvailableTemplates, ShareType, ImageType, type ShareLinkCreateRequest, type ShareImageCreateRequest } from '../api/index';
 import type { Mascot, Item } from '../types/api';
 import { usePointStore } from '../stores/point';
 
@@ -446,22 +446,9 @@ function showSharePopup() {
 // 백엔드 연결 상태 확인
 async function checkBackendStatus() {
   try {
-    const response = await fetch(`${import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api/v1'}/share/templates`, {
-      headers: {
-        'Authorization': `Bearer ${auth.getToken()}`
-      }
-    });
-    console.log('백엔드 연결 상태:', response.status, response.ok);
-    
-    // 토큰 만료 체크
-    if (response.status === 401) {
-      console.log('토큰이 만료되었습니다. 로그인 페이지로 이동합니다.');
-      showToastMessage('로그인이 만료되었습니다. 로그인 페이지로 이동합니다.');
-      setTimeout(() => {
-        auth.clearAuth();
-        router.push('/');
-      }, 2000);
-    }
+    // 공유 템플릿 목록을 호출하여 백엔드 연결 확인
+    await getAvailableTemplates();
+    console.log('백엔드 연결 상태: OK');
   } catch (error) {
     console.error('백엔드 연결 실패:', error);
   }


### PR DESCRIPTION


인증 안정화와 서버 주도 처리로 초기 타이밍 이슈를 해소하고, 랭킹/출석 기능을 사용 가능한 상태로 정비했습니다. 프론트-백엔드 경로/스키마 차이
를 맞추고, DB 유니크 인덱스로 무결성을 보강했습니다.

변경 사항

- 백엔드
    - auth: GET /api/v1/auth/me → ApiResponse<UserResponse>(userId, username, nickname, campus, totalPoints 등)로 확장
    - ranking: 조회 권한 완화(기존 MASTER → isAuthenticated()), GET /api/v1/rankings/campus|national
    - attendance: 신규 API 추가
    - GET `/api/v1/attendance/today`: 당일 출석 여부
    - POST `/api/v1/attendance`: 출석 처리 + 일일 보너스 포인트 지급
- security: CORS 설정을 .env/application.yml 값(cors.*)으로 읽도록 수정
- db: Flyway 마이그레이션
    - `mascots(user_id)` 유니크 인덱스
    - `votes(idempotency_key)` 유니크 인덱스(멱등 요청 보장)

- 프론트엔드
    - api 유틸: VITE_API_BASE_URL 사용, 401 시 /auth/refresh 후 원 요청 1회 재시도, fetchUser 중복/재시도
    - ranking api: 서버 ApiResponse 언랩, 투표 시 userId 본문 제거(JWT로 서버 식별)
    - ranking view: 첫 진입 시 bootstrapAuth()+isAuthenticatedAsync()로 인증 동기화, 인증 실패시 라우팅 처리
    - mascot: 공유 템플릿 경로 /shares/templates로 정정, Authorization 헤더 제거(apiRequest 사용)
    - attendance: 신규 API 연동(/attendance, /attendance/today)

마이그레이션

- 파일: backend/solsol/src/main/resources/db/migration/V1_1__add_unique_indexes_mascots_votes.sql
- 적용: 애플리케이션 실행 시 Flyway가 자동 적용
- 주의: 운영 DB에 인덱스 추가가 포함되므로 배포 창구에서 점검 권장

검증 방법

- 백엔드 실행: cd backend/solsol && ./gradlew bootRun
- 인증 응답 확인: GET /api/v1/auth/me → data.userId, data.nickname 등 포함
- 랭킹 조회: GET /api/v1/rankings/campus 정상 응답(로그인 필요)
- 출석:
    - POST /api/v1/attendance → 201, 보상 반환
    - GET /api/v1/attendance/today → {"data":{"attended":true}}
- 프론트 실행: cd frontend && npm ci && npm run dev
    - 초기 진입 시 인증 동기화 정상
    - 랭킹 탭 데이터 표시, 투표 호출 정상
    - 마스코트 공유 템플릿 호출 정상
    - 출석 화면에서 오늘 출석 여부/체크 동작

호환성/리스크

- /auth/me 응답 스키마 변경(이제 ApiResponse 래핑) → FE 반영 완료
- 랭킹 조회 권한 완화는 기획 의도를 재확인 필요(의도된 공개 범위인지 체크)
- votes 멱등키 유니크 적용으로 중복 요청 시 409 가능(클라이언트 재시도 로직 고려)

체크리스트

- [ ] 기획 기준 랭킹 공개 범위 확인 완료
- [ ] 운영 DB 마이그레이션 확인
- [ ] CORS 환경 변수(prod) 점검
- [ ] 추가로 Friend API FE 경로/메서드 정합성 정리 예정 (후속 PR)

참고

- 브랜치: feature/auth-attendance-hardening
- 주요 커밋: auth/me 확장, 랭킹 권한 완화, attendance API 추가, API 유틸 표준화, 경로/언랩 정리