### PR TITLE
Feat: 챌린지 주기별로 리셋기능 추가

### DIFF
--- a/backend/solsol/src/main/java/com/solsolhey/challenge/dto/response/ChallengeProgressResponseDto.java
+++ b/backend/solsol/src/main/java/com/solsolhey/challenge/dto/response/ChallengeProgressResponseDto.java
@@ -1,6 +1,8 @@
 package com.solsolhey.challenge.dto.response;
 
+import com.solsolhey.challenge.entity.Challenge;
 import com.solsolhey.challenge.entity.UserChallenge;
+import com.solsolhey.challenge.entity.UserChallengeCycle;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,6 +34,19 @@ public class ChallengeProgressResponseDto {
                 .isCompleted(isCompleted)
                 .rewardPoints(isCompleted ? userChallenge.getChallenge().getRewardPoints() : null)
                 .rewardExp(isCompleted ? userChallenge.getChallenge().getRewardExp() : null)
+                .build();
+    }
+
+    // 주기 진행 응답(주기 레코드 기반)
+    public static ChallengeProgressResponseDto successCycle(UserChallengeCycle cycle, Challenge challenge) {
+        boolean isCompleted = cycle.isCompleted();
+        return ChallengeProgressResponseDto.builder()
+                .success(true)
+                .message(isCompleted ? "챌린지를 완료했습니다! 보상이 지급되었습니다." : "진행도가 업데이트되었습니다.")
+                .userChallenge(UserChallengeDto.fromCycle(cycle))
+                .isCompleted(isCompleted)
+                .rewardPoints(isCompleted ? challenge.getRewardPoints() : null)
+                .rewardExp(isCompleted ? challenge.getRewardExp() : null)
                 .build();
     }
 

--- a/backend/solsol/src/main/java/com/solsolhey/challenge/dto/response/UserChallengeDto.java
+++ b/backend/solsol/src/main/java/com/solsolhey/challenge/dto/response/UserChallengeDto.java
@@ -1,6 +1,7 @@
 package com.solsolhey.challenge.dto.response;
 
 import com.solsolhey.challenge.entity.UserChallenge;
+import com.solsolhey.challenge.entity.UserChallengeCycle;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,6 +39,21 @@ public class UserChallengeDto {
                 .startedAt(userChallenge.getStartedAt())
                 .completedAt(userChallenge.getCompletedAt())
                 .progressData(userChallenge.getProgressData())
+                .build();
+    }
+
+    // 주기 진행 레코드 기반 매핑 (프론트 호환을 위해 동일 필드에 매핑)
+    public static UserChallengeDto fromCycle(UserChallengeCycle cycle) {
+        return UserChallengeDto.builder()
+                .userChallengeId(cycle.getCycleId())
+                .status(cycle.getStatus().name())
+                .statusDisplayName(cycle.getStatus().getDisplayName())
+                .progressCount(cycle.getProgressCount())
+                .targetCount(cycle.getTargetCount())
+                .progressRate(cycle.getProgressRate())
+                .startedAt(cycle.getStartedAt())
+                .completedAt(cycle.getCompletedAt())
+                .progressData(cycle.getProgressData())
                 .build();
     }
 }

--- a/backend/solsol/src/main/java/com/solsolhey/challenge/entity/Challenge.java
+++ b/backend/solsol/src/main/java/com/solsolhey/challenge/entity/Challenge.java
@@ -60,6 +60,20 @@ public class Challenge extends BaseEntity {
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = true;
 
+    // 리셋 정책: 일부 챌린지만 일일 리셋 적용
+    public enum ResetPolicy { NONE, DAILY, WEEKLY, MONTHLY }
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reset_policy", nullable = false, length = 20)
+    private ResetPolicy resetPolicy = ResetPolicy.NONE;
+
+    // 리셋 기준: CALENDAR(캘린더 기준) | COMPLETION(완료일 기준)
+    public enum ResetAnchor { CALENDAR, COMPLETION }
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reset_anchor", nullable = false, length = 20)
+    private ResetAnchor resetAnchor = ResetAnchor.CALENDAR;
+
     @Builder
     public Challenge(ChallengeCategory category, String challengeName, String description,
                     Integer rewardPoints, Integer rewardExp, ChallengeType challengeType,

--- a/backend/solsol/src/main/java/com/solsolhey/challenge/entity/UserChallengeCycle.java
+++ b/backend/solsol/src/main/java/com/solsolhey/challenge/entity/UserChallengeCycle.java
@@ -1,0 +1,121 @@
+package com.solsolhey.challenge.entity;
+
+import com.solsolhey.user.entity.BaseEntity;
+import com.solsolhey.user.entity.User;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자-챌린지 주기별 진행 엔티티 (KST LocalDate 기준)
+ * cycleType: DAILY | WEEKLY | MONTHLY
+ * cycleKeyDate: 해당 주기의 시작일(LocalDate)
+ */
+@Entity
+@Table(name = "user_challenge_cycle",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "challenge_id", "cycle_type", "cycle_key_date"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserChallengeCycle extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cycle_id")
+    private Long cycleId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "challenge_id", nullable = false)
+    private Challenge challenge;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cycle_type", nullable = false, length = 20)
+    private Challenge.ResetPolicy cycleType;
+
+    @Column(name = "cycle_key_date", nullable = false)
+    private LocalDate cycleKeyDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private UserChallenge.ChallengeStatus status = UserChallenge.ChallengeStatus.NOT_STARTED;
+
+    @Column(name = "progress_count", nullable = false)
+    private Integer progressCount = 0;
+
+    @Column(name = "target_count", nullable = false)
+    private Integer targetCount;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "progress_data", columnDefinition = "TEXT")
+    private String progressData;
+
+    @Builder
+    public UserChallengeCycle(User user, Challenge challenge, Challenge.ResetPolicy cycleType, LocalDate cycleKeyDate) {
+        this.user = user;
+        this.challenge = challenge;
+        this.cycleType = cycleType;
+        this.cycleKeyDate = cycleKeyDate;
+        this.status = UserChallenge.ChallengeStatus.NOT_STARTED;
+        this.progressCount = 0;
+        this.targetCount = challenge.getTargetCount();
+    }
+
+    public void start() {
+        if (this.status == UserChallenge.ChallengeStatus.NOT_STARTED) {
+            this.status = UserChallenge.ChallengeStatus.IN_PROGRESS;
+            this.startedAt = LocalDateTime.now();
+        }
+    }
+
+    public void updateProgress(Integer progress) {
+        if (this.status == UserChallenge.ChallengeStatus.IN_PROGRESS) {
+            this.progressCount = Math.min(progress, this.targetCount);
+            if (this.progressCount >= this.targetCount) {
+                complete();
+            }
+        }
+    }
+
+    public void incrementProgress() { updateProgress(this.progressCount + 1); }
+
+    public void complete() {
+        if (this.status == UserChallenge.ChallengeStatus.IN_PROGRESS) {
+            this.status = UserChallenge.ChallengeStatus.COMPLETED;
+            this.completedAt = LocalDateTime.now();
+        }
+    }
+
+    public void fail() {
+        if (this.status == UserChallenge.ChallengeStatus.IN_PROGRESS) {
+            this.status = UserChallenge.ChallengeStatus.FAILED;
+        }
+    }
+
+    public void expire() {
+        if (this.status == UserChallenge.ChallengeStatus.IN_PROGRESS || this.status == UserChallenge.ChallengeStatus.NOT_STARTED) {
+            this.status = UserChallenge.ChallengeStatus.EXPIRED;
+        }
+    }
+
+    public double getProgressRate() {
+        if (this.targetCount == 0) return 0.0;
+        return Math.min(1.0, (double) this.progressCount / this.targetCount);
+    }
+
+    public boolean isCompleted() { return this.status == UserChallenge.ChallengeStatus.COMPLETED; }
+    public boolean isInProgress() { return this.status == UserChallenge.ChallengeStatus.IN_PROGRESS; }
+    public void updateProgressData(String progressData) { this.progressData = progressData; }
+}
+

--- a/backend/solsol/src/main/java/com/solsolhey/challenge/repository/UserChallengeCycleRepository.java
+++ b/backend/solsol/src/main/java/com/solsolhey/challenge/repository/UserChallengeCycleRepository.java
@@ -1,0 +1,29 @@
+package com.solsolhey.challenge.repository;
+
+import com.solsolhey.challenge.entity.Challenge;
+import com.solsolhey.challenge.entity.UserChallengeCycle;
+import com.solsolhey.user.entity.User;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface UserChallengeCycleRepository extends JpaRepository<UserChallengeCycle, Long> {
+
+    Optional<UserChallengeCycle> findByUserAndChallengeAndCycleTypeAndCycleKeyDate(
+            User user, Challenge challenge, Challenge.ResetPolicy cycleType, LocalDate cycleKeyDate);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<UserChallengeCycle> findWithLockByUserAndChallengeAndCycleTypeAndCycleKeyDate(
+            User user, Challenge challenge, Challenge.ResetPolicy cycleType, LocalDate cycleKeyDate);
+
+    Optional<UserChallengeCycle> findTopByUserAndChallengeAndCycleTypeOrderByStartedAtDesc(
+            User user, Challenge challenge, Challenge.ResetPolicy cycleType);
+
+    Optional<UserChallengeCycle> findTopByUserAndChallengeAndCycleTypeOrderByCompletedAtDesc(
+            User user, Challenge challenge, Challenge.ResetPolicy cycleType);
+}

--- a/backend/solsol/src/main/java/com/solsolhey/challenge/service/ChallengeServiceImpl.java
+++ b/backend/solsol/src/main/java/com/solsolhey/challenge/service/ChallengeServiceImpl.java
@@ -13,7 +13,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -29,9 +32,12 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     private final ChallengeRepository challengeRepository;
     private final UserChallengeRepository userChallengeRepository;
+    private final UserChallengeCycleRepository userChallengeCycleRepository;
     private final ChallengeCategoryRepository categoryRepository;
     private final PointService pointService;
     private final com.solsolhey.exp.service.ExpDailyCounterService expDailyCounterService;
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     /**
      * 챌린지 목록 조회
@@ -75,10 +81,46 @@ public class ChallengeServiceImpl implements ChallengeService {
                     
                     // 현재 사용자의 참여 정보 설정
                     Optional<UserChallenge> userChallenge = userChallengeRepository.findByUserAndChallenge(currentUser, challenge);
-                    if (userChallenge.isPresent()) {
-                        dto.setUserInfo(true, userChallenge.get().getStatus().name());
+                    if (challenge.getResetPolicy() == Challenge.ResetPolicy.NONE) {
+                        if (userChallenge.isPresent()) {
+                            dto.setUserInfo(true, userChallenge.get().getStatus().name());
+                        } else {
+                            dto.setUserInfo(false, "NOT_JOINED");
+                        }
                     } else {
-                        dto.setUserInfo(false, "NOT_JOINED");
+                        if (challenge.getResetAnchor() == Challenge.ResetAnchor.CALENDAR) {
+                            LocalDate key = currentCycleKey(challenge.getResetPolicy());
+                            var cycleOpt = userChallengeCycleRepository
+                                    .findByUserAndChallengeAndCycleTypeAndCycleKeyDate(currentUser, challenge, challenge.getResetPolicy(), key);
+                            boolean joinedInCycle = cycleOpt
+                                    .map(c -> c.getStatus() == UserChallenge.ChallengeStatus.IN_PROGRESS || c.getStatus() == UserChallenge.ChallengeStatus.COMPLETED)
+                                    .orElse(false);
+                            String status = cycleOpt.map(c -> c.getStatus().name()).orElse("NOT_STARTED");
+                            dto.setUserInfo(joinedInCycle, status);
+                        } else { // COMPLETION 기반
+                            var latestOpt = userChallengeCycleRepository
+                                    .findTopByUserAndChallengeAndCycleTypeOrderByStartedAtDesc(currentUser, challenge, challenge.getResetPolicy());
+                            boolean joined;
+                            String status;
+                            if (latestOpt.isPresent()) {
+                                var latest = latestOpt.get();
+                                if (latest.getStatus() == UserChallenge.ChallengeStatus.IN_PROGRESS) {
+                                    joined = true; status = latest.getStatus().name();
+                                } else if (latest.getStatus() == UserChallenge.ChallengeStatus.COMPLETED) {
+                                    var next = nextAvailableFromCompletion(latest, challenge.getResetPolicy());
+                                    if (next != null && LocalDateTime.now(KST).isBefore(next)) {
+                                        joined = true; status = latest.getStatus().name();
+                                    } else {
+                                        joined = false; status = "NOT_STARTED";
+                                    }
+                                } else {
+                                    joined = false; status = "NOT_STARTED";
+                                }
+                            } else {
+                                joined = false; status = "NOT_STARTED";
+                            }
+                            dto.setUserInfo(joined, status);
+                        }
                     }
                     
                     return dto;
@@ -110,7 +152,37 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         // 현재 사용자의 참여 정보 설정
         Optional<UserChallenge> userChallenge = userChallengeRepository.findByUserAndChallenge(currentUser, challenge);
-        response.setUserInfo(userChallenge.isPresent(), userChallenge.orElse(null));
+        if (challenge.getResetPolicy() == Challenge.ResetPolicy.NONE) {
+            response.setUserInfo(userChallenge.isPresent(), userChallenge.orElse(null));
+        } else {
+            if (challenge.getResetAnchor() == Challenge.ResetAnchor.CALENDAR) {
+                LocalDate key = currentCycleKey(challenge.getResetPolicy());
+                var cycleOpt = userChallengeCycleRepository
+                        .findByUserAndChallengeAndCycleTypeAndCycleKeyDate(currentUser, challenge, challenge.getResetPolicy(), key);
+                boolean joinedInCycle = cycleOpt
+                        .map(c -> c.getStatus() == UserChallenge.ChallengeStatus.IN_PROGRESS || c.getStatus() == UserChallenge.ChallengeStatus.COMPLETED)
+                        .orElse(false);
+                response.setUserInfo(joinedInCycle, userChallenge.orElse(null));
+            } else { // COMPLETION
+                var latestOpt = userChallengeCycleRepository
+                        .findTopByUserAndChallengeAndCycleTypeOrderByStartedAtDesc(currentUser, challenge, challenge.getResetPolicy());
+                boolean joined;
+                if (latestOpt.isPresent()) {
+                    var latest = latestOpt.get();
+                    if (latest.getStatus() == UserChallenge.ChallengeStatus.IN_PROGRESS) {
+                        joined = true;
+                    } else if (latest.getStatus() == UserChallenge.ChallengeStatus.COMPLETED) {
+                        var next = nextAvailableFromCompletion(latest, challenge.getResetPolicy());
+                        joined = next != null && LocalDateTime.now(KST).isBefore(next);
+                    } else {
+                        joined = false;
+                    }
+                } else {
+                    joined = false;
+                }
+                response.setUserInfo(joined, userChallenge.orElse(null));
+            }
+        }
 
         log.info("챌린지 상세 조회 완료: challengeId={}", challengeId);
         return response;
@@ -131,21 +203,29 @@ public class ChallengeServiceImpl implements ChallengeService {
             return ChallengeJoinResponseDto.failure("참여할 수 없는 챌린지입니다.");
         }
 
-        // 이미 참여한 챌린지인지 확인
-        if (userChallengeRepository.existsByUserAndChallenge(user, challenge)) {
-            return ChallengeJoinResponseDto.failure("이미 참여한 챌린지입니다.");
+        // 리셋 정책(DAILY/WEEKLY/MONTHLY): Enrollment 존재 여부와 무관하게 해당 주기 진행 시작 허용
+        UserChallenge savedUserChallenge;
+        if (challenge.getResetPolicy() != Challenge.ResetPolicy.NONE) {
+            Optional<UserChallenge> enrollmentOpt = userChallengeRepository.findByUserAndChallenge(user, challenge);
+            if (enrollmentOpt.isEmpty()) {
+                UserChallenge enrollment = UserChallenge.builder().user(user).challenge(challenge).build();
+                enrollment.start();
+                savedUserChallenge = userChallengeRepository.save(enrollment);
+            } else {
+                savedUserChallenge = enrollmentOpt.get();
+            }
+            // 해당 주기 진행 생성/시작
+            var cycle = ensureJoinAllowedAndGetCycle(user, challenge);
+            if (cycle.getStatus() == UserChallenge.ChallengeStatus.NOT_STARTED) cycle.start();
+        } else {
+            // 기존 정책: 이미 참여했으면 차단
+            if (userChallengeRepository.existsByUserAndChallenge(user, challenge)) {
+                return ChallengeJoinResponseDto.failure("이미 참여한 챌린지입니다.");
+            }
+            UserChallenge userChallenge = UserChallenge.builder().user(user).challenge(challenge).build();
+            userChallenge.start();
+            savedUserChallenge = userChallengeRepository.save(userChallenge);
         }
-
-        // UserChallenge 생성
-        UserChallenge userChallenge = UserChallenge.builder()
-                .user(user)
-                .challenge(challenge)
-                .build();
-        
-        // 참여와 동시에 시작
-        userChallenge.start();
-        
-        UserChallenge savedUserChallenge = userChallengeRepository.save(userChallenge);
 
         // EXP: 챌린지 참여 카테고리 1일 1회 +5 (마스코트 존재 시)
         java.util.Optional<com.solsolhey.exp.service.ExpDailyCounterService.ExpAwarded> catAwarded = java.util.Optional.empty();
@@ -181,14 +261,49 @@ public class ChallengeServiceImpl implements ChallengeService {
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new EntityNotFoundException("챌린지", challengeId));
 
+        // 주기 분기
+        if (challenge.getResetPolicy() != Challenge.ResetPolicy.NONE) {
+            var cycle = ensureJoinAllowedAndGetCycle(user, challenge);
+            if (!(cycle.isInProgress() || cycle.getStatus() == UserChallenge.ChallengeStatus.NOT_STARTED)) {
+                return ChallengeProgressResponseDto.failure("진행 중인 챌린지가 아닙니다.");
+            }
+            if (cycle.getStatus() == UserChallenge.ChallengeStatus.NOT_STARTED) {
+                cycle.start();
+            }
+            // 금융 방어 동일 적용
+            boolean isFinance = challenge.getCategory().getCategoryName() == ChallengeCategory.CategoryType.FINANCE;
+            if (isFinance && isFinanceActionChallenge(challenge)) {
+                String payload = request.getPayload();
+                boolean validFinanceSuccess = payload != null && payload.startsWith("FINANCE_") && payload.endsWith("_SUCCESS");
+                if (!validFinanceSuccess) {
+                    log.warn("금융 API형 챌린지 진행도 갱신 무시(DAILY): payload 누락/무효. challengeId={}, userId={}, step={}, payload={}",
+                            challengeId, user.getUserId(), request.getStepValue(), payload);
+                    return ChallengeProgressResponseDto.failure("외부 조회를 완료한 뒤에 완료할 수 있습니다.");
+                }
+            }
+            cycle.updateProgress(request.getStepValue());
+            if (request.getPayload() != null) cycle.updateProgressData(request.getPayload());
+            // 완료 보상: 오늘 처음 COMPLETED 전이에만 지급
+            if (cycle.isCompleted()) {
+                try {
+                    pointService.awardChallengeReward(user, challenge.getRewardPoints(), challenge.getChallengeId());
+                    log.info("(CYCLE) 챌린지 완료 보상 지급: userId={}, challengeId={}, points={}",
+                            user.getUserId(), challengeId, challenge.getRewardPoints());
+                } catch (Exception e) {
+                    log.error("(CYCLE) 챌린지 보상 지급 실패: userId={}, challengeId={}", user.getUserId(), challengeId, e);
+                }
+            }
+            log.info("(CYCLE) 진행 갱신: challengeId={}, userId={}, progress={}/{} completed={}",
+                    challengeId, user.getUserId(), cycle.getProgressCount(), cycle.getTargetCount(), cycle.isCompleted());
+            return ChallengeProgressResponseDto.successCycle(cycle, challenge);
+        }
+
+        // 기존(Non-DAILY) 경로
         UserChallenge userChallenge = userChallengeRepository.findByUserAndChallenge(user, challenge)
                 .orElseThrow(() -> new BusinessException("참여하지 않은 챌린지입니다."));
-
-        // 진행 중인 챌린지인지 확인
         if (!userChallenge.isInProgress()) {
             return ChallengeProgressResponseDto.failure("진행 중인 챌린지가 아닙니다.");
         }
-
         boolean wasCompleted = userChallenge.isCompleted();
 
         // 진행도 업데이트 (FINANCE 카테고리 방어 로직) — 실제 금융 API 액션으로 인식되는 경우만 제한
@@ -229,6 +344,69 @@ public class ChallengeServiceImpl implements ChallengeService {
                 savedUserChallenge.getTargetCount(), savedUserChallenge.isCompleted());
 
         return ChallengeProgressResponseDto.success(savedUserChallenge);
+    }
+
+    private UserChallengeCycle getOrCreateCycleLocked(User user, Challenge challenge, Challenge.ResetPolicy cycleType, LocalDate cycleKeyDate) {
+        return userChallengeCycleRepository.findWithLockByUserAndChallengeAndCycleTypeAndCycleKeyDate(user, challenge, cycleType, cycleKeyDate)
+                .orElseGet(() -> {
+                    UserChallengeCycle created = UserChallengeCycle.builder()
+                            .user(user)
+                            .challenge(challenge)
+                            .cycleType(cycleType)
+                            .cycleKeyDate(cycleKeyDate)
+                            .build();
+                    try {
+                        return userChallengeCycleRepository.save(created);
+                    } catch (Exception e) {
+                        return userChallengeCycleRepository.findWithLockByUserAndChallengeAndCycleTypeAndCycleKeyDate(user, challenge, cycleType, cycleKeyDate)
+                                .orElseThrow(() -> new IllegalStateException("Failed to acquire challenge cycle row"));
+                    }
+                });
+    }
+
+    private LocalDate currentCycleKey(Challenge.ResetPolicy policy) {
+        LocalDate today = LocalDate.now(KST);
+        return switch (policy) {
+            case DAILY -> today;
+            case WEEKLY -> today.with(DayOfWeek.MONDAY);
+            case MONTHLY -> today.withDayOfMonth(1);
+            default -> today;
+        };
+    }
+
+    private LocalDateTime nextAvailableFromCompletion(UserChallengeCycle cycle, Challenge.ResetPolicy policy) {
+        if (cycle.getCompletedAt() == null) return null;
+        return switch (policy) {
+            case DAILY -> cycle.getCompletedAt().plusDays(1);
+            case WEEKLY -> cycle.getCompletedAt().plusDays(7);
+            case MONTHLY -> cycle.getCompletedAt().plusMonths(1);
+            default -> cycle.getCompletedAt();
+        };
+    }
+
+    private UserChallengeCycle ensureJoinAllowedAndGetCycle(User user, Challenge challenge) {
+        if (challenge.getResetAnchor() == Challenge.ResetAnchor.CALENDAR) {
+            LocalDate key = currentCycleKey(challenge.getResetPolicy());
+            return getOrCreateCycleLocked(user, challenge, challenge.getResetPolicy(), key);
+        }
+        // COMPLETION 기반: 쿨다운 확인
+        var latestOpt = userChallengeCycleRepository
+                .findTopByUserAndChallengeAndCycleTypeOrderByStartedAtDesc(user, challenge, challenge.getResetPolicy());
+        if (latestOpt.isPresent()) {
+            var latest = latestOpt.get();
+            if (latest.getStatus() == UserChallenge.ChallengeStatus.IN_PROGRESS) {
+                return latest; // 이미 진행 중인 사이클 사용
+            }
+            if (latest.getStatus() == UserChallenge.ChallengeStatus.COMPLETED) {
+                var next = nextAvailableFromCompletion(latest, challenge.getResetPolicy());
+                if (next != null && LocalDateTime.now(KST).isBefore(next)) {
+                    throw new BusinessException("아직 재참여 가능한 시간이 아닙니다.");
+                }
+            }
+        }
+        // 새 사이클 생성: cycle_key_date는 시작일(LocalDate.now)
+        LocalDate key = LocalDate.now(KST);
+        return getOrCreateCycleLocked(user, challenge, challenge.getResetPolicy(), key);
     }
 
     private boolean isFinanceActionChallenge(Challenge challenge) {

--- a/backend/solsol/src/main/resources/db/migration/V30__challenge_cycle_table.sql
+++ b/backend/solsol/src/main/resources/db/migration/V30__challenge_cycle_table.sql
@@ -1,0 +1,59 @@
+-- Add reset_policy column to challenge (for selective resets)
+ALTER TABLE challenge
+    ADD COLUMN IF NOT EXISTS reset_policy VARCHAR(20) NOT NULL DEFAULT 'NONE';
+ALTER TABLE challenge
+    ADD COLUMN IF NOT EXISTS reset_anchor VARCHAR(20) NOT NULL DEFAULT 'CALENDAR';
+
+-- Create generalized cycle table for challenge resets (DAILY/WEEKLY/MONTHLY)
+CREATE TABLE IF NOT EXISTS user_challenge_cycle (
+    cycle_id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    challenge_id BIGINT NOT NULL,
+    cycle_type VARCHAR(20) NOT NULL,
+    cycle_key_date DATE NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    progress_count INT NOT NULL DEFAULT 0,
+    target_count INT NOT NULL,
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP,
+    progress_data TEXT,
+    CONSTRAINT uq_user_challenge_cycle UNIQUE (user_id, challenge_id, cycle_type, cycle_key_date),
+    CONSTRAINT fk_ucc_user FOREIGN KEY (user_id) REFERENCES users(user_id),
+    CONSTRAINT fk_ucc_challenge FOREIGN KEY (challenge_id) REFERENCES challenge(challenge_id)
+);
+
+-- Helpful indexes
+CREATE INDEX IF NOT EXISTS idx_ucc_challenge_cycle ON user_challenge_cycle (challenge_id, cycle_type, cycle_key_date);
+CREATE INDEX IF NOT EXISTS idx_ucc_user_cycle ON user_challenge_cycle (user_id, cycle_type, cycle_key_date);
+
+-- Set reset policies for specific challenges (idempotent name-based updates)
+-- DAILY resets
+UPDATE challenge SET reset_policy = 'DAILY'
+WHERE challenge_name IN (
+  '매일 2시간 공부하기',
+  '환율 전체 조회하기',
+  '환율 단건 확인하기',
+  '환율 단건 조회',
+  '환전 예상 계산하기',
+  '환전 예상 계산',
+  '나의 계좌 거래내역 조회',
+  '나의 계좌거래내역 조회'
+);
+
+-- WEEKLY resets
+UPDATE challenge SET reset_policy = 'WEEKLY'
+WHERE challenge_name IN (
+  '친구와 함께 커피 마시기',
+  '7일 연속 용돈 기입장 작성하기',
+  '과제 미루지 않기'
+);
+
+-- MONTHLY resets
+UPDATE challenge SET reset_policy = 'MONTHLY'
+WHERE challenge_name IN (
+  '한 달 예산 계획 세우기',
+  '한달 예산 계획'
+);
+
+-- Anchor rules: weekly/monthly use COMPLETION-based reset; daily keeps CALENDAR(default)
+UPDATE challenge SET reset_anchor = 'COMPLETION' WHERE reset_policy IN ('WEEKLY', 'MONTHLY');


### PR DESCRIPTION
챌린지 한달, 일주일, 매일 주기로 리셋되어서 다시 참여할 수 있도록 수정 (완료일 기준으로 계산)
- 매일 2시간 공부하기, 환율 전체 조회, 환율 단건 조회, 환전 예상 계산, 나의 계좌거래내역 조회는 매일 리셋
- 친구와 함께 커피 마시기, 7일 연속 용돈 기입장 작성하기, 과제 미루지 않기는 일주일에 한번 리셋
- 한달 예산 계획은 한달마다 리셋
